### PR TITLE
Update README.md with use so key pair generation example code works

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ import {Ed25519VerificationKey2020} from
 
 const didKeyDriver = driver();
 
+didKeyDriver.use({
+  multibaseMultikeyHeader: 'z6Mk',
+  fromMultibase: Ed25519VerificationKey2020.from
+});
+
 const publicKeyMultibase = 'z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
 const verificationKeyPair = await Ed25519VerificationKey2020.from({
   publicKeyMultibase


### PR DESCRIPTION
When I used this library, I attempted to copy the code as is from the README and received this error

```
Error: Unsupported "multibaseMultikeyHeader", "z6Mk".
```

So I've added the required `didKeyDriver.use` lines to the example so it can work without error.